### PR TITLE
Fix Firebase redirect to home

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,8 +1,5 @@
 {
   "hosting": {
-    "public": "public",
-    "rewrites": [
-      { "source": "**", "destination": "/index.html" }
-    ]
+    "public": "public"
   }
 }


### PR DESCRIPTION
## Summary
- remove SPA-style rewrite rule from `firebase.json`

This avoids redirecting all paths to `index.html`, allowing the login page to
redirect users to `home.html` properly.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f2f230b58832f8235c255124863e8