### PR TITLE
Simplify register page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Este repositorio contiene un conjunto de páginas HTML diseñadas para gestionar
 
 ## Estructura del sitio
 - **home.html**: página de entrada principal. Desde aquí se accede a `login.html` e `register.html`.
-- **login.html / register.html**: formularios de autenticación. `login.html` (o `index.html` si se renombra) carga el script `login.js` para gestionar el inicio de sesión con Firebase y tras autenticar redirige a `home.html`.
+- **login.html**: formulario de acceso para usuarios existentes. Utiliza `login.js` para autenticar con Firebase y luego redirige a `home.html`.
+- **register.html**: permite crear una cuenta nueva. Incluye un script interno que inicializa Firebase y gestiona el registro.
 - **listado-maestro.html**: panel central para el control de documentación. Requiere autenticación.
 - **amfe.html**: herramienta de análisis AMFE. Requiere autenticación.
 - **sinoptico-producto.html**: visualización jerárquica de componentes. Requiere autenticación.

--- a/public/register.html
+++ b/public/register.html
@@ -16,9 +16,6 @@
     </style>
 </head>
 <body class="bg-gray-100 flex flex-col items-center justify-start min-h-screen py-12">
-    <div id="header-container">
-        <div class="bg-gray-800 h-16 flex items-center justify-center text-white w-full">Cargando encabezado...</div>
-    </div>
 
     <div class="w-full max-w-md p-8 space-y-4 bg-white rounded-xl shadow-lg">
         <!-- Encabezado -->
@@ -80,11 +77,21 @@
     </div>
 
     <!-- SDKs de Firebase -->
-    <script type="module" src="app.js"></script>
     <script type="module">
+        import { initializeApp } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-app.js";
         import { getAuth, GoogleAuthProvider, signInWithPopup, createUserWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-auth.js";
 
-        const auth = getAuth();
+        const firebaseConfig = {
+            apiKey: "AIzaSyD4FopYX645rwDYGSQTdDV0VObqds6q34g",
+            authDomain: "proyecto-barack-4f731.firebaseapp.com",
+            projectId: "proyecto-barack-4f731",
+            storageBucket: "proyecto-barack-4f731.appspot.com",
+            messagingSenderId: "730750717116",
+            appId: "1:730750717116:web:1fbcab2cbb59e0d83454b9"
+        };
+
+        const app = initializeApp(firebaseConfig);
+        const auth = getAuth(app);
         const googleProvider = new GoogleAuthProvider();
 
         // =================================================================================


### PR DESCRIPTION
## Summary
- clean up register page dependencies
- embed Firebase initialization in register page script
- clarify authentication pages in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f5784353c832fbc162cea10c7585d