### PR TITLE
Remove google verification meta

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -3,7 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="google-site-verification" content="CVmYYIJ3BkgCY6vGZM-gnO1TXFg0L8Rkwb_rFQMZUSw" />
     <title>Proyecto Barack - Ingeniería Automotriz</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- remove Google site verification tag from the home page

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685fef0fd5a0832faa50d07fbf9025ee