### PR TITLE
Add Firebase App Check with reCAPTCHA v3

### DIFF
--- a/public/amfe.html
+++ b/public/amfe.html
@@ -329,6 +329,7 @@
         modalsContainer.querySelector('#confirmation-modal .modal-cancel-btn').addEventListener('click', hideConfirmationModal);
     });
     </script>
+<script src="https://www.google.com/recaptcha/api.js?render=6LdzJ3ErAAAAAAHV3HV1x8vIOjm3lcehnfWfjYT6r"></script>
 <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/public/app.js
+++ b/public/app.js
@@ -1,6 +1,7 @@
 // --- app.js (Debe incluirse en todas las páginas protegidas) ---
 
 import { initializeApp } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-app.js";
+import { initializeAppCheck, ReCaptchaV3Provider } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-app-check.js";
 import { getAuth, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-auth.js";
 
 // 1. Configuración de Firebase
@@ -12,9 +13,22 @@ const firebaseConfig = {
     messagingSenderId: "730750717116",
     appId: "1:730750717116:web:1fbcab2cbb59e0d83454b9"
 };
+const recaptchaV3SiteKey = "6LdzJ3ErAAAAAAHV3HV1x8vIOjm3lcehnfWfjYT6r";
+
+function setupAppCheck(firebaseApp) {
+    if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
+        self.FIREBASE_APPCHECK_DEBUG_TOKEN = true;
+    }
+    initializeAppCheck(firebaseApp, {
+        provider: new ReCaptchaV3Provider(recaptchaV3SiteKey),
+        isTokenAutoRefreshEnabled: true
+    });
+    console.log('✅ Firebase App Check inicializado con reCAPTCHA v3');
+}
 
 // Inicializa Firebase y Auth
 const app = initializeApp(firebaseConfig);
+setupAppCheck(app);
 const auth = getAuth(app);
 const loginPage = 'login.html';
 

--- a/public/demo-lista-maestra.html
+++ b/public/demo-lista-maestra.html
@@ -14,6 +14,7 @@
     </div>
 
     <ul id="lista" class="space-y-2"></ul>
+<script src="https://www.google.com/recaptcha/api.js?render=6LdzJ3ErAAAAAAHV3HV1x8vIOjm3lcehnfWfjYT6r"></script>
 
     <script type="module">
         import { addItem, subscribeToList } from './lista-maestra.js';

--- a/public/home.html
+++ b/public/home.html
@@ -140,6 +140,7 @@
         const observer = new IntersectionObserver((entries) => { entries.forEach(entry => { if (entry.isIntersecting) { entry.target.classList.add('is-visible'); } }); }, { threshold: 0.1 });
         document.querySelectorAll('.fade-in-section').forEach(section => observer.observe(section));
     </script>
+    <script src="https://www.google.com/recaptcha/api.js?render=6LdzJ3ErAAAAAAHV3HV1x8vIOjm3lcehnfWfjYT6r"></script>
     <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/public/lista-maestra.js
+++ b/public/lista-maestra.js
@@ -3,6 +3,7 @@
 // to push items and subscribe to real-time updates.
 
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.6.1/firebase-app.js';
+import { initializeAppCheck, ReCaptchaV3Provider } from 'https://www.gstatic.com/firebasejs/9.6.1/firebase-app-check.js';
 import { getDatabase, ref, push, onChildAdded, onChildChanged, onChildRemoved } from 'https://www.gstatic.com/firebasejs/9.6.1/firebase-database.js';
 
 // Firebase configuration for proyecto-barack-4f731
@@ -15,9 +16,22 @@ const firebaseConfig = {
     messagingSenderId: "730750717116",
     appId: "1:730750717116:web:1fbcab2cbb59e0d83454b9"
 };
+const recaptchaV3SiteKey = "6LdzJ3ErAAAAAAHV3HV1x8vIOjm3lcehnfWfjYT6r";
+
+function setupAppCheck(firebaseApp) {
+    if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
+        self.FIREBASE_APPCHECK_DEBUG_TOKEN = true;
+    }
+    initializeAppCheck(firebaseApp, {
+        provider: new ReCaptchaV3Provider(recaptchaV3SiteKey),
+        isTokenAutoRefreshEnabled: true
+    });
+    console.log('✅ Firebase App Check inicializado con reCAPTCHA v3');
+}
 
 // Initialize Firebase app and Database service
 const app = initializeApp(firebaseConfig);
+setupAppCheck(app);
 const db = getDatabase(app);
 
 // Reference to the master list in the database

--- a/public/login.html
+++ b/public/login.html
@@ -73,6 +73,7 @@
     </div>
 
     <!-- SDKs de Firebase -->
+    <script src="https://www.google.com/recaptcha/api.js?render=6LdzJ3ErAAAAAAHV3HV1x8vIOjm3lcehnfWfjYT6r"></script>
     <script type="module" src="login.js"></script>
 </body>
 </html>

--- a/public/login.js
+++ b/public/login.js
@@ -1,4 +1,5 @@
 import { initializeApp } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-app.js";
+import { initializeAppCheck, ReCaptchaV3Provider } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-app-check.js";
 import {
     getAuth,
     onAuthStateChanged,
@@ -15,8 +16,21 @@ const firebaseConfig = {
     messagingSenderId: "730750717116",
     appId: "1:730750717116:web:1fbcab2cbb59e0d83454b9"
 };
+const recaptchaV3SiteKey = "6LdzJ3ErAAAAAAHV3HV1x8vIOjm3lcehnfWfjYT6r";
+
+function setupAppCheck(firebaseApp) {
+    if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
+        self.FIREBASE_APPCHECK_DEBUG_TOKEN = true;
+    }
+    initializeAppCheck(firebaseApp, {
+        provider: new ReCaptchaV3Provider(recaptchaV3SiteKey),
+        isTokenAutoRefreshEnabled: true
+    });
+    console.log('✅ Firebase App Check inicializado con reCAPTCHA v3');
+}
 
 const app = initializeApp(firebaseConfig);
+setupAppCheck(app);
 const auth = getAuth(app);
 const googleProvider = new GoogleAuthProvider();
 

--- a/public/register.html
+++ b/public/register.html
@@ -78,8 +78,10 @@
     </div>
 
     <!-- SDKs de Firebase -->
+    <script src="https://www.google.com/recaptcha/api.js?render=6LdzJ3ErAAAAAAHV3HV1x8vIOjm3lcehnfWfjYT6r"></script>
     <script type="module">
         import { initializeApp } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-app.js";
+        import { initializeAppCheck, ReCaptchaV3Provider } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-app-check.js";
         import { getAuth, GoogleAuthProvider, signInWithPopup, createUserWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-auth.js";
 
         const firebaseConfig = {
@@ -90,8 +92,21 @@
             messagingSenderId: "730750717116",
             appId: "1:730750717116:web:1fbcab2cbb59e0d83454b9"
         };
+        const recaptchaV3SiteKey = "6LdzJ3ErAAAAAAHV3HV1x8vIOjm3lcehnfWfjYT6r";
+
+        function setupAppCheck(firebaseApp) {
+            if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
+                self.FIREBASE_APPCHECK_DEBUG_TOKEN = true;
+            }
+            initializeAppCheck(firebaseApp, {
+                provider: new ReCaptchaV3Provider(recaptchaV3SiteKey),
+                isTokenAutoRefreshEnabled: true
+            });
+            console.log('✅ Firebase App Check inicializado con reCAPTCHA v3');
+        }
 
         const app = initializeApp(firebaseConfig);
+        setupAppCheck(app);
         const auth = getAuth(app);
         const googleProvider = new GoogleAuthProvider();
 

--- a/public/sinoptico-producto.html
+++ b/public/sinoptico-producto.html
@@ -21,6 +21,7 @@
         <h1 class="text-3xl font-bold mb-4">Sinóptico de Producto</h1>
         <p class="text-gray-600">Contenido en construcción.</p>
     </div>
+<script src="https://www.google.com/recaptcha/api.js?render=6LdzJ3ErAAAAAAHV3HV1x8vIOjm3lcehnfWfjYT6r"></script>
 
     <script type="module" src="app.js"></script>
 </div>


### PR DESCRIPTION
## Summary
- load reCAPTCHA v3 on all Firebase pages
- initialize Firebase App Check in app.js
- enable App Check in login and demo modules
- add App Check setup in register page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68603d96c1f0832f9da9ec9cda7998b3