### PR TITLE
Fix navigation buttons and init app on list page

### DIFF
--- a/public/listado-maestro.html
+++ b/public/listado-maestro.html
@@ -91,13 +91,13 @@
         <div class="container mx-auto px-4 md:px-6">
             <div class="flex items-center justify-between h-16">
                 <div class="flex items-center">
-                    <a href="#" class="flex items-center text-white hover:text-gray-200 transition-colors">
+                    <a href="home.html" class="flex items-center text-white hover:text-gray-200 transition-colors">
                         <i class="fas fa-terminal mr-3 text-xl"></i>
                         <span class="font-bold text-lg">Proyecto Barack</span>
                     </a>
                     <div class="hidden md:flex items-center ml-6">
-                         <a href="#" class="text-gray-300 hover:bg-corporate-dark hover:text-white px-3 py-2 rounded-md text-sm font-medium">Inicio</a>
-                         <a href="#" class="bg-gray-700/50 text-white px-3 py-2 rounded-md text-sm font-medium ml-4" aria-current="page">Listado Maestro</a>
+                         <a href="home.html" class="text-gray-300 hover:bg-corporate-dark hover:text-white px-3 py-2 rounded-md text-sm font-medium">Inicio</a>
+                         <a href="listado-maestro.html" class="bg-gray-700/50 text-white px-3 py-2 rounded-md text-sm font-medium ml-4" aria-current="page">Listado Maestro</a>
                     </div>
                 </div>
                 <div class="flex items-center">
@@ -482,6 +482,8 @@
 
         App.init();
     });
-    </script>
+</script>
+    <script src="https://www.google.com/recaptcha/api.js?render=6LdzJ3ErAAAAAAHV3HV1x8vIOjm3lcehnfWfjYT6r"></script>
+    <script type="module" src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable navigation links in `listado-maestro.html`
- load reCAPTCHA and app initialization scripts

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686040f0e978832f8667e3f3e4322962